### PR TITLE
Foundry v13 compatibility fixes proposal

### DIFF
--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -137,9 +137,10 @@ export class PokeroleCombat extends Combat {
 
 export class PokeroleCombatTracker extends foundry.applications.sidebar.tabs.CombatTracker {
   static registerHooks() {
-    Hooks.on('renderCombatTracker', (tracker, elem) => {
+    Hooks.on("renderCombatTracker", (tracker, elem) => {
       // Show the number of actions each combatant has taken
-      for (const combatantElem of elem.getElementsByClassName("combatant")) {
+	  var combatantElems = elem.querySelectorAll(".combatant");
+      for (const combatantElem of combatantElems) {
         const combatantId = combatantElem.dataset.combatantId;
         const actor = game.combat?.combatants?.get(combatantId)?.actor;
         if (!actor) return;
@@ -182,7 +183,12 @@ export class PokeroleCombatTracker extends foundry.applications.sidebar.tabs.Com
 
         resetRoundButton.appendChild(icon);
 
-        elem.getElementsByClassName("combat-controls")[0].append(resetRoundButton);
+		var combatControlElems = elem.querySelectorAll("#combat-controls");
+		for(const combatControlElem of combatControlElems)
+		{
+			combatControlElems[combatControlElem].append(resetRoundButton);
+		}
+        
 
         resetRoundButton.addEventListener('click', () => {
           game.combat.turn = -1;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -353,8 +353,17 @@ export class PokeroleItem extends Item {
    * @param {HTML} html  Rendered chat message.
    */
   static chatListeners(html) {
-    $(html).on("click", ".card-buttons button", this._onChatCardAction.bind(this));
-    $(html).on("click", ".item-name", this._onChatCardToggleContent.bind(this));
+	var buttons = html.querySelectorAll(".card-buttons button");
+	for(var i = 0 ; i < buttons.length; i++)
+	{
+		buttons[i].addEventListener("click", this._onChatCardAction.bind(this));
+	}
+
+	var itemNames = html.querySelectorAll(".item-name");
+	for(var i = 0 ; i < itemNames.length; i++)
+	{
+		itemNames[i].addEventListener("click", this._onChatCardToggleContent.bind(this));
+	}
   }
 
     /* -------------------------------------------- */

--- a/module/helpers/clash.mjs
+++ b/module/helpers/clash.mjs
@@ -43,7 +43,7 @@ export async function showClashDialog(actor, actorToken, attacker, attackingMove
 
   let defaultPainPenalty = actor.system.painPenalty ?? 'none';
 
-  const content = await renderTemplate(CLASH_DIALOGUE_TEMPLATE, {
+  const content = await foundry.applications.handlebars.renderTemplate(CLASH_DIALOGUE_TEMPLATE, {
     moves,
     painPenalty: defaultPainPenalty,
     painPenalties: getLocalizedPainPenaltiesForSelect(),
@@ -68,7 +68,7 @@ export async function showClashDialog(actor, actorToken, attacker, attackingMove
   if (!result) return undefined;
 
   const formElement = result[0].querySelector('form');
-  let { moveId, painPenalty, poolBonus, constantBonus, confusionPenalty } = new FormDataExtended(formElement).object;
+  let { moveId, painPenalty, poolBonus, constantBonus, confusionPenalty } = new foundry.applications.ux.FormDataExtended(formElement).object;
   constantBonus ??= 0;
   if (confusionPenalty) {
     constantBonus--;

--- a/module/helpers/effects.mjs
+++ b/module/helpers/effects.mjs
@@ -244,7 +244,7 @@ export async function addAilmentWithDialog(actor, category) {
         moves[move.uuid] = move.name;
       }
 
-      const content = await renderTemplate(DISABLE_MOVE_DIALOG_TEMPLATE, {
+      const content = await foundry.applications.handlebars.renderTemplate(DISABLE_MOVE_DIALOG_TEMPLATE, {
         moves
       });
       const result = await new Promise(resolve => {
@@ -268,7 +268,7 @@ export async function addAilmentWithDialog(actor, category) {
 
       if (!result) return undefined;
       const formElement = result[0].querySelector('form');
-      const { moveUuid } = new FormDataExtended(formElement).object;
+      const { moveUuid } = new foundry.applications.ux.FormDataExtended(formElement).object;
       options.moveUuid = moveUuid;
 
       break;

--- a/module/pokerole.mjs
+++ b/module/pokerole.mjs
@@ -69,8 +69,7 @@ Hooks.once("ready", async function () {
 });
 
 // Chat message hooks
-Hooks.on('renderChatLog', (app, html, data) => PokeroleItem.chatListeners(html));
-Hooks.on('renderChatPopout', (app, html, data) => PokeroleItem.chatListeners(html));
+Hooks.on('renderChatMessageHTML', (app, html, data) => PokeroleItem.chatListeners(html));
 
 PokeroleCombatTracker.registerHooks();
 registerIntegrationHooks();


### PR DESCRIPTION
Series of minor fixes for compatibility with Foundry version 13, as listed below:

- Added explicit namespaces to certain API calls soon to be marked as deprecated
- Chat listeners now hooks onto renderChatMessageHTML rather than renderChatPopout and renderChatLog
- Chat card buttons now search for the appropriate element explicitly through QuerySelectorAll
- Combat tracker now searches for the appropriate button elements explicitly through QuerySelectorAll